### PR TITLE
Fix and clarification for the R dependencies

### DIFF
--- a/docs/Installation.rst
+++ b/docs/Installation.rst
@@ -19,12 +19,12 @@ The default installation will install everything needed to run circtools *except
 
 .. code-block:: bash
 
-    pip3 install circtools --user # does not require root access, installation to local user directory
+    pip3 install circtools --user
 
-.. code-block:: bash
+Please note:
 
-    pip3 install circtools # will require root access and globally install circtools
-
+* The required R libraries will be installed in the default location in your home directory - unless you set enviromnet variable $R_LIBS_USER.
+* In case want to install globally or into a dedicated 'venv' drop the --user option.
 
 Installation from GitHub
 --------------------------

--- a/scripts/install_R_dependencies.R
+++ b/scripts/install_R_dependencies.R
@@ -49,13 +49,15 @@ options(repos = c(CRAN = "https://cran.uni-muenster.de/"))
 # check if devtools is already installed
 pkgs <- pkgs[!pkgs %in% installed.packages()[,1]]
 
-print("R minor version:")
+minorVersion <- as.numeric(strsplit(version[['minor']], '')[[1]][[1]])
+majorVersion <- as.numeric(strsplit(version[['major']], '')[[1]][[1]])
 
-print(as.numeric(strsplit(version[['minor']], '')[[1]][[1]]) )
+print(paste("R version: ", majorVersion, ".", minorVersion, sep=""))
 
-# new installer caller for R >3.6.0
-if (as.numeric(strsplit(version[['minor']], '')[[1]][[1]]) >= 6){
-
+if (
+    majorVersion >= 4
+    || ( majorVersion == 3 && minorVersion >= 6 )
+){
     if (!requireNamespace("BiocManager", quietly = TRUE))
         install.packages("BiocManager")
 


### PR DESCRIPTION
It seems that the R dependencies relies on a check of the minor R version only (>=6) to select
the right method to install  BiocManager. That assumes major version 3 and will not work for R 4.0 to 4.5.

Another very minor issue with the R dependencies is that it was not documented where they are installed. I added a small remark about that to the documentation as well.